### PR TITLE
Update url releases

### DIFF
--- a/install/assets/plugins/modxupdatenotifer.tpl
+++ b/install/assets/plugins/modxupdatenotifer.tpl
@@ -23,7 +23,7 @@ $output = '';
         $cache = new RSSCache(MODX_BASE_PATH.'assets/cache/', $cache_lifetime*3600);
         if($cache->check_cache('unw') != 'HIT'){
                 $ch = curl_init();
-                $url = 'https://api.github.com/repos/dmi3yy/modx.evo.custom/tags';
+                $url = 'https://api.github.com/repos/dmi3yy/modx.evo.custom/releases';
                 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
                 curl_setopt($ch, CURLOPT_HEADER, false);
 			//curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);


### PR DESCRIPTION
URL tags выдаёт версии в непонятной сортировке. Поэтому текущая версия админки клиента не совпадает с реализом на гите.
URL releases выдаёт версии сортированные, как я проанализировал, по дате